### PR TITLE
Add Info command to web socket api

### DIFF
--- a/lib/api/socketapi.js
+++ b/lib/api/socketapi.js
@@ -54,6 +54,11 @@ var socket = nodejsWebsocket.createServer(function (conn) {
 function set (d, conn) {
 	var command = d.shift();
 	switch (command) {
+		case 'info':
+				helper.log.debug('[' + conn.socket.remoteAddress + '] info call');
+				var d = data.getData('actuators');
+				conn.sendText(JSON.stringify({'result': d}));
+			break;
 		case 'set':
 			if (d.length == 4 || d.length == 5) {
 				helper.log.debug('set channel ' + d[2] + ' of ' + d[0] + ' ' + d[1] + ' to ' + d[3] + (d.length == 5 ? ' (' + d[4] + ')' : ''));
@@ -64,7 +69,7 @@ function set (d, conn) {
 				helper.log.error('[' + conn.socket.remoteAddress + '] invalid set command: ' + d.join('/'));
 			}
 			break;
-			
+
 		case 'raw':
 			if (d.length == 4) {
 				helper.log.debug('raw set: ' + d[0] + '/' + d[1] + '/' + d[2] + ': ' + d[3]);
@@ -75,27 +80,27 @@ function set (d, conn) {
 				helper.log.error('[' + conn.socket.remoteAddress + '] invalid raw command: ' + d.join('/'));
 			}
 			break;
-		
+
 		case 'weather':
 			var weather = data.getActuatorData('weather', 'ch0000');
 			conn.sendText(JSON.stringify({'weather': weather}));
 			break;
-		
+
 		case 'daynight':
 			var daynight = data.getActuatorData('daynight', 'ch0000');
 			conn.sendText(JSON.stringify({'daynight': daynight}));
 			break;
-		
+
 		case 'status':
 			var status = data.getData('status');
 			conn.sendText(JSON.stringify({'status': status}));
 			break;
-		
+
 		case 'structure':
 			var structure = data.getData('structure');
 			conn.sendText(JSON.stringify({'structure': structure}));
 			break;
-		
+
 		case 'update':
 			if (d.length == 1 && d[0] == 'all') {
 				sysap_external.updateAll();
@@ -105,7 +110,7 @@ function set (d, conn) {
 				conn.sendText(JSON.stringify({'result': 'pushed update'}));
 			}
 			break;
-			
+
 		case 'logLevel':
 			if (d.length == 1) {
 				var newlogLevel = d[0];
@@ -123,7 +128,7 @@ function set (d, conn) {
 				helper.log.error('[' + conn.socket.remoteAddress + '] invaild logLevel command: ' + d.join('/'));
 			}
 			break;
-		
+
 		case 'logFilter':
 			if (d.length < 1 || (d.length == 1 && d[0] == '')) {
 				global.logFilter = false;
@@ -137,11 +142,11 @@ function set (d, conn) {
 		case 'message':
 			helper.log.info('[' + conn.socket.remoteAddress + '] websocket message: ' + d.join('/'));
 			break;
-		
+
 		case 'powermeter':
 			helper.log.info('[' + conn.socket.remoteAddress + '] Power Meter: ' + "\n" + d.join('/'));
 			break;
-		
+
 		default:
 			helper.log.error('[' + conn.socket.remoteAddress + '] unknown command: ' + command);
 	}
@@ -152,7 +157,7 @@ var lastBroadcast = '';
 /**
  * sends a message to all currently connected clients
  * The message is usually an encoded JSON or plain text. A message is only sent if the message is different from the previous message (md5).
- * 
+ *
  * @param {String} msg
  */
 var broadcast = function (msg) {

--- a/lib/api/socketapi.js
+++ b/lib/api/socketapi.js
@@ -56,8 +56,19 @@ function set (d, conn) {
 	switch (command) {
 		case 'info':
 				helper.log.debug('[' + conn.socket.remoteAddress + '] info call');
-				var d = data.getData('actuators');
-				conn.sendText(JSON.stringify({'result': d}));
+				var actuators = data.getData('actuators');
+
+				if (d.length >= 1 && actuators[d[0]]) {
+					actuators = actuators[d[0]];
+					if (d.length >= 2 && actuators.channels[d[1]]) {
+						actuators = actuators.channels[d[1]];
+						if (d.length >= 3 && actuators.datapoints[d[2]]) {
+							actuators = actuators.datapoints[d[2]];
+						}
+					}
+				}
+
+				conn.sendText(JSON.stringify({'result': actuators}));
 			break;
 		case 'set':
 			if (d.length == 4 || d.length == 5) {


### PR DESCRIPTION
The info command is currently missing from the web socket api.
I'm currently working on a homebridge project that requires this command to be available via the web socket api so it would be nice if we could add this.