### PR TITLE
Update config.default.js

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -18,7 +18,7 @@ config.webapi = {
 // config for Busch Jäger free@home
 config.bosh = {
 	url: 'http://' + SYSAP_HOST + ':5280/http-bind',
-	jid: SYSAP_URL,
+	jid: SYSAP_JID,
 	resource: 'nodeapi',
 	password: SYSAP_PASSWORD
 };


### PR DESCRIPTION
SYSAP_URL is not a valid variable, running into an error when running node.
SYSAP_JID should be used in this case I think.